### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 -m src.solver"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/djm4556/ustores_solver)](https://repl.it/github/djm4556/ustores_solver)
+
 # BUG REPORT: 0
 This section stores known bugs if there are any. Luckily, there are none- it's all patched!
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).